### PR TITLE
fix dwOffset type to allow bigger values

### DIFF
--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -34,7 +34,7 @@ HRESULT STDMETHODCALLTYPE Util::WriteByte(
 
     BYTE bValue = V_UI1(&pDispParams->rgvarg[2]);
     PBYTE lpAddress = (PBYTE)V_UI8(&pDispParams->rgvarg[1]);
-    WORD wOffset = V_I4(&pDispParams->rgvarg[0]);
+    DWORD dwOffset = V_I4(&pDispParams->rgvarg[0]);
 
     // Write byte
     *(lpAddress + wOffset) = bValue;

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -37,7 +37,7 @@ HRESULT STDMETHODCALLTYPE Util::WriteByte(
     DWORD dwOffset = V_I4(&pDispParams->rgvarg[0]);
 
     // Write byte
-    *(lpAddress + wOffset) = bValue;
+    *(lpAddress + dwOffset) = bValue;
 
     if (pVarResult != NULL) {
         V_VT(pVarResult) = VT_BOOL;


### PR DESCRIPTION
Changed the type of wOffset in `Utils.cpp` to allow bigger offsets.

When copying bigger shellcodes, the offset used in the WriteByte function overflowed and caused errors when trying to copy buffers bigger than 2^16 elements. Changed the type from WORD to DWORD to fix that.